### PR TITLE
fix: fix data labels for pie and doughnut graphs

### DIFF
--- a/modules/visualize/graph-oid.js
+++ b/modules/visualize/graph-oid.js
@@ -14,7 +14,10 @@ export class GraphOid extends OidUI {
     this.placeholder.style.display = 'none';
     if (this.chart) this.chart.destroy();
 
-    Chart.register(ChartDataLabels);
+    if(this.type != "pie" && this.type != "doughnut"){
+      Chart.register(ChartDataLabels);
+    }
+    
     Chart.register(zoomPlugin);
     
     this.chart = new Chart(this.canvas, createConfiguration(this.type, message.value, this.fields, 

--- a/modules/visualize/index_forno.html
+++ b/modules/visualize/index_forno.html
@@ -19,7 +19,7 @@
   <h1>Playground</h1>
   <data-sender-oid publish="click~render/data"> </data-sender-oid>
   <export-button-oid publish="export~graph/export"></export-button-oid>
-  <graph-oid uid="graph-1" type="line" fields='{"x": 0, "y": 1}' subscribe="render/data~render;graph/export~export"></graph-oid>
+  <graph-oid uid="graph-1" type="doughnut" fields='{"x": 0, "y": 1}' subscribe="render/data~render;graph/export~export"></graph-oid>
   <canvas id="forcing-canvas"></canvas>
 </body>
 </html>


### PR DESCRIPTION
This PR ensure that for pie and doughnut graphs the DataLabels won't be registred for Chart.js