### PR TITLE
QOL: Hint on core Classes

### DIFF
--- a/modules/workflow/src/js/components/node-input-field.js
+++ b/modules/workflow/src/js/components/node-input-field.js
@@ -58,5 +58,8 @@ export class NodeInputField{
     handleSetInputValue(inputValue){
         this.inputValue = inputValue;
     }
+    getName(){
+        return this.name
+    }
     
 }

--- a/modules/workflow/src/js/components/node-input-field.js
+++ b/modules/workflow/src/js/components/node-input-field.js
@@ -28,6 +28,8 @@ export class NodeInputField{
             }
         }
     */
+   
+
 
     constructor(name, view, parameters){
         this.name = name;

--- a/modules/workflow/src/js/components/world-space-node-connector.js
+++ b/modules/workflow/src/js/components/world-space-node-connector.js
@@ -1,3 +1,10 @@
+import { WorldSpaceNode } from "./world-space-node";
+
+/**
+ * Represents the connectors of a WorldSpaceNode where connections can be made.
+ * @property {WorldSpaceNode} parentWorldSpaceNode - The node that owns the connector.
+ * @property {Array.<worldSpaceNodeConnector>} connectedWorldSpaceConnectors - The list of connectors connected to this connector.
+ */
 export class worldSpaceNodeConnector {
 
     /*
@@ -12,11 +19,26 @@ export class worldSpaceNodeConnector {
 
     */
 
+
+     /**
+     * Creates a new worldSpaceNodeConnector instance.
+     * @param {WorldSpaceNode} parentWorldSpaceNode - The parent WorldSpaceNode.
+     */
+
     constructor(parentWorldSpaceNode) {
+        /** @type {WorldSpaceNode} */
         this.parentWorldSpaceNode = parentWorldSpaceNode;
-        this.connectedWorldSpaceConnectors = []
+        /** @type {Array.<worldSpaceNodeConnector>} */
+        this.connectedWorldSpaceConnectors = [];
+
     }
 
+    /**
+     * Checks if a connection can be made between a source connector and a target connector.
+     * @param {worldSpaceNodeConnectorOut} sourceConnector - The source connector.
+     * @param {worldSpaceNodeConnectorIn} targetConnector - The target connector.
+     * @returns {boolean} - True if the connection can be made, false otherwise.
+     */
 
     static canConnectionHappen(/*worldSpaceNodeConnectorOut*/ sourceConnector, /*worldSpaceNodeConnectorIn*/ targetConnector) {
         //Verifies if the parentNode type can be connected to the targetInput
@@ -63,7 +85,11 @@ export class worldSpaceNodeConnector {
 
         }
     }
-
+    /**
+    * Removes a connection between the current connector and another connector.
+    * @param {worldSpaceNodeConnector} connector - The connector to remove the connection from.
+    * @returns {boolean} - True if the connection was removed successfully, false otherwise.
+    */
     removeConnection(/*worldSpaceNodeConnector*/ connector) {
 
         var indexSelf = connector.connectedWorldSpaceConnectors.indexOf(this);
@@ -78,19 +104,29 @@ export class worldSpaceNodeConnector {
         console.log("Problem removing connection")
         return false;
     }
-
-    isConnectedTo(/*worldSpaceNodeConnector*/ connected) {
-
+    /**
+     * Checks if the current connector is connected to another connector.
+     * @param {worldSpaceNodeConnector} connected - The connector to check the connection with.
+     * @returns {boolean} - True if the current connector is connected to the other connector, false otherwise.
+     */
+    isConnectedTo(connected) {
         var indexSelf = connected.connectedWorldSpaceConnectors.indexOf(this);
         var indexOther = this.connectedWorldSpaceConnectors.indexOf(connected);
 
         return indexSelf >= 0 && indexOther >= 0;
     }
-
+    /**
+     * Returns the parent WorldSpaceNode of the connector.
+     * @returns {WorldSpaceNode} - The parent WorldSpaceNode.
+     */
     getParentNode() {
         return this.parentWorldSpaceNode;
     }
 
+    /**
+    * Returns the ID of the parent WorldSpaceNode.
+    * @returns {number} - The ID of the parent WorldSpaceNode.
+    */
     getParentNodeId() {
         return this.parentWorldSpaceNode.individualId;
     }
@@ -104,6 +140,12 @@ export class worldSpaceNodeConnector {
         });
 
     }
+    /**
+    * Checks if a restriction is respected based on the output type and input restriction.
+    * @param {string} outType - The output type.
+    * @param {string} inRestriction - The input restriction.
+    * @returns {boolean} - True if the restriction is respected, false otherwise.
+     */
     static isRestrictionRespected(outType, inRestriction) {
 
         const segmentosA = outType.split("/");
@@ -123,51 +165,76 @@ export class worldSpaceNodeConnector {
 
 
 }
-export class worldSpaceNodeConnectorIn extends worldSpaceNodeConnector {
-    /*
-    Input Connectors have type and ammount limitations.
 
-    compatipleNodes = Dict{typeIds:String}   
-    connectionsRange:[int,int]
-    */
-   
+/**
+ * Represents an input connector of a WorldSpaceNode where connections can be made.
+ * @extends worldSpaceNodeConnector
+ */
+export class worldSpaceNodeConnectorIn extends worldSpaceNodeConnector {
+    /**
+     * Creates a new worldSpaceNodeConnectorIn instance.
+     * @param {WorldSpaceNode} parentWorldSpaceNode - The parent WorldSpaceNode.
+     * @param {Array.<string>} compatibleNodes - The dictionary of compatible node types.
+     * @param {[number, number]} connectionsRange - The range of connections allowed.
+     */
     constructor(parentWorldSpaceNode, compatibleNodes, connectionsRange) {
         super(parentWorldSpaceNode);
+        /** @type {Array.<string>} */
         this.compatibleNodes = compatibleNodes;
+        /** @type {[number, number]} */
         this.connectionsRange = connectionsRange;
     }
 
-    receiveConnectionFrom(/*worldSpaceNodeConnectorOut*/ sourceConnector) {
-        //add the connector to this input's registered connections
+    /**
+     * Receives a connection from a source connector and adds it to the list of connectedWorldSpaceConnectors.
+     * @param {worldSpaceNodeConnectorOut} sourceConnector - The source connector.
+     */
+    receiveConnectionFrom(sourceConnector) {
         this.connectedWorldSpaceConnectors.push(sourceConnector);
-
     }
 
+    /**
+     * Gets the accepted input types of the connector.
+     * @returns {Array.<string>} - The accepted types hierarchy.
+     */
     getAcceptedInputTypes() {
-        //Returns the accepted types hierarchy
         return this.compatibleNodes;
-
     }
-
 }
-export class worldSpaceNodeConnectorOut extends worldSpaceNodeConnector {
-    /*
-    Output Connectors have type and ammount limitations. (symmetrical to input connectors)
-    */
 
+
+/**
+ * Represents an output connector of a WorldSpaceNode where connections can be made.
+ * @extends worldSpaceNodeConnector
+ */
+export class worldSpaceNodeConnectorOut extends worldSpaceNodeConnector {
+    /**
+     * Creates a new worldSpaceNodeConnectorOut instance.
+     * @param {WorldSpaceNode} parentWorldSpaceNode - The parent WorldSpaceNode.
+     * @param {string} outputType - The output type.
+     * @param {[number, number]} connectionsRange - The range of connections allowed.
+     */
     constructor(parentWorldSpaceNode, outputType, connectionsRange) {
         super(parentWorldSpaceNode);
+        /** @type {string} */
         this.outputType = outputType;
+        /** @type {[number, number]} */
         this.connectionsRange = connectionsRange;
     }
 
-    addConnectionTo(/*worldSpaceNodeConnector*/ targetConnector) {
-
+    /**
+     * Adds a connection to a target connector and updates the connectedWorldSpaceConnectors list.
+     * @param {worldSpaceNodeConnectorIn} targetConnector - The target connector.
+     */
+    addConnectionTo(targetConnector) {
         this.connectedWorldSpaceConnectors.push(targetConnector);
     }
 
+    /**
+     * Gets the provided output types of the connector.
+     * @returns {string} - The exported types hierarchy.
+     */
     getProvidedOutputTypes() {
-        //Returns the exported types hierarchy
         return this.outputType;
     }
 }

--- a/modules/workflow/src/js/components/world-space-node.js
+++ b/modules/workflow/src/js/components/world-space-node.js
@@ -1,49 +1,50 @@
 import { NodeInputField } from "./node-input-field.js";
-import { worldSpaceNodeConnectorIn, worldSpaceNodeConnectorOut } from "./world-space-node-connector.js";
+import { worldSpaceNodeConnector, worldSpaceNodeConnectorIn, worldSpaceNodeConnectorOut } from "./world-space-node-connector.js";
 import { WorldSpaceSubcomponentBehaviour } from "./world-space-subcomponent-behaviour.js"
 import { WorldSpaceNodeTypes } from "../world-space-node-types.js"
 
 
 export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {
-    /*
-    Representa os nodes que estarão localizados no espaço do workflow
-    Possui:
-        output: Lista de portas de saída e suas informações
-        id: Identificador geral da função do nó
-        name: Nome do nó, utilizado somente para a sua visualização
-        presentable: Se o nó possui visualização gráfica ao final do workflow
-        icon: Caminho para o ícone que representa visualmente o nó
-        input: Lista de portas de entrada e suas informações
-        fields: Lista de campos onde o usuário coloca informações para modificar o posicionamento
-    
-    output : [{"type": [string], "name": string, "range": [int, int]}]
-    id : string
-    name : string
-    presentable : boolean
-    icon : string
-    input : [{type: [string], name: string, range: [int, int]}]
-    fields : [name : string, view : string, parameters : {par1 : value01 , par2 : value02, ...}]
-
-    Example:
-        output : [{type: ["graph/scatter"], name: Saída do Gráfico, range: [1, 1]}],
-        id : "visualize:scatter-plot",
-        name : "Scatter Plot",
-        presentable : true,
-        icon : "/assets/scatter.jpg",
-        input : [{type: ["input"], name: Dados, range: [1, 1]}],
-        fields : [{
-            name : "Título", 
-            view : "TextBox", 
-            parameters : {
-                password : false,
-                maxLength : 10,
-                minLength : 1,
-                forbidden : ["abcde"],
-                placeholder : "Insira o título aqui"
-            }]
-        }
-    */
-
+    /**
+     * Represents the nodes located in the workflow space.
+     * @extends WorldSpaceSubcomponentBehaviour
+     *
+     * Properties:
+     * output: List of output ports and their information
+     * id: General identifier of the node's function
+     * name: Name of the node, used for visualization purposes only
+     * presentable: Indicates if the node has a graphical representation at the end of the workflow
+     * icon: Path to the icon that visually represents the node
+     * input: List of input ports and their information
+     * fields: List of fields where the user inputs information to modify the positioning
+     *
+     * @property {Array.<worldSpaceNodeConnectorOut>} output
+     * @property {number} id
+     * @property {string} name
+     * @property {boolean} presentable
+     * @property {string} icon
+     * @property {Array.<worldSpaceNodeConnectorIn>} input
+     * @property {Array.<NodeInputField>} fields
+     *
+     * @example
+     * output: [{type: ["graph/scatter"], name: "Saída do Gráfico", range: [1, 1]}],
+     * id: "visualize:scatter-plot",
+     * name: "Scatter Plot",
+     * presentable: true,
+     * icon: "/assets/scatter.jpg",
+     * input: [{type: ["input"], name: "Dados", range: [1, 1]}],
+     * fields: [{
+     *     name: "Título",
+     *     view: "TextBox",
+     *     parameters: {
+     *         password: false,
+     *         maxLength: 10,
+     *         minLength: 1,
+     *         forbidden: ["abcde"],
+     *         placeholder: "Insira o título aqui"
+     *     }
+     * }]
+     */
     nodeValues = {};
 
     handleGetValues(key) {
@@ -60,18 +61,25 @@ export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {
         if (!(id in NodeInfoLib)) {
             throw `Error: ${id} is not a known node`;
         }
-        var NodeInfo = NodeInfoLib[id];
-
+        /** @type {Array.<worldSpaceNodeConnectorOut>} */
+        this.output = [];
+        /** @type {number} */
         this.id = id;
+        /** @type {string} */
         this.name = name;
-        this.presentable = NodeInfo["presentable"];
-        this.icon = NodeInfo["icon"];
+        /** @type {boolean} */
+        this.presentable = false;
+        /** @type {string} */
+        this.icon = "";
+        /** @type {Array.<worldSpaceNodeConnectorIn>} */
+        this.input = [];
+        /** @type {Array.<NodeInputField>} */
         this.fields = [];
 
         for (var i = 0; i < NodeInfo["output"].length; i++) {
             var compatible = NodeInfo["output"][i];
             var newOutput = new worldSpaceNodeConnectorOut(this, compatible["type"], compatible["range"]);
-            this.outputConnection.push(newOutput);
+            this.output.push(newOutput);
         }
         for (var i = 0; i < NodeInfo["input"].length; i++) {
             var compatible = NodeInfo["input"][i];
@@ -87,12 +95,9 @@ export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {
     }
     //fields: [ {name: string, view: string , parameters: [number or string]}]
     /*List<fields>*/ handleGetUserFields() {
-        return this.fields;
+        return WorldSpaceNodeTypes.NodeInfoLib[this.type]["fields"]
     }
 
-    getNodeType(){
-        return this.id;
-    }
     Destroy() {
         /*Deletes itself and removes reference from the nodes targeting it and receiving from it, safety measurement */
         //TODO ->Remove reference from the nodes receiving and giving connections to this
@@ -104,20 +109,27 @@ export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {
     //NODE -> VERTICE
     //EDGE -> CONNECTION
 
+    /**
+     * Returns the vertices that this node is making connections to.
+     * @returns {Array.<Number>} - The target vertices.
+     */
     getTargetVertices() {
         //RETURNS THE VERTICES THIS ONE IS MAKING CONNECTION **TO**
-        vertices = [];
+        
+        let vertices = [];
+        this.output.forEach((targetInConnector) => {
 
-        this.outputConnection.forEach((targetInConnector) => {
-
-            vertices.push(targetInConnector.getParentNodeId);
+            vertices.push(targetInConnector.getParentNodeId());
 
         });
 
         return vertices;
 
     }
-
+    /**
+     * Checks if the graph is cyclic.
+     * @returns {boolean} - True if cyclic, false otherwise.
+     */
     isGraphCyclic() {
         const stack = [this];
         const visited = new Set();

--- a/modules/workflow/src/js/components/world-space-node.js
+++ b/modules/workflow/src/js/components/world-space-node.js
@@ -31,7 +31,7 @@ export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {
         presentable : true,
         icon : "/assets/scatter.jpg",
         input : [{type: ["input"], name: Dados, range: [1, 1]}],
-        fields : {
+        fields : [{
             name : "Título", 
             view : "TextBox", 
             parameters : {
@@ -40,7 +40,7 @@ export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {
                 minLength : 1,
                 forbidden : ["abcde"],
                 placeholder : "Insira o título aqui"
-            }
+            }]
         }
     */
 
@@ -87,9 +87,12 @@ export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {
     }
     //fields: [ {name: string, view: string , parameters: [number or string]}]
     /*List<fields>*/ handleGetUserFields() {
-        return WorldSpaceNodeTypes.NodeInfoLib[this.type]["fields"]
+        return this.fields;
     }
 
+    getNodeType(){
+        return this.id;
+    }
     Destroy() {
         /*Deletes itself and removes reference from the nodes targeting it and receiving from it, safety measurement */
         //TODO ->Remove reference from the nodes receiving and giving connections to this

--- a/modules/workflow/src/js/components/world-space-subcomponent-behaviour.js
+++ b/modules/workflow/src/js/components/world-space-subcomponent-behaviour.js
@@ -2,48 +2,50 @@ import { Vector2 } from "./auxiliary-types.js";
 import { WorldSpace } from "./world-space.js";
 import { OidBase } from "../oidlib-dev.js";
 
-
+/**
+ * Represents any component that can be in the workflow space. @extends OidBase
+ */
 export class WorldSpaceSubcomponentBehaviour extends OidBase {
-    /*
-        Representa qualquer componente que possa estar no espaço do workflow
-    */
-
-    /*
-    individualId: Int
-    position: Vector2
-    */
-
-
+    /**
+     * @param {Vector2} position - The initial position of the component. Defaults to (0, 0).
+     */
     constructor(position = new Vector2(0, 0)) {
-
+        super();
+        /** @type {Vector2} - The position of the component. */
         this.position = position;
+        /** @type {number} - The individual ID of the component. */
         this.individualId = WorldSpace.createdWSSubcomponentsAmmount;
         WorldSpace.createdWSSubcomponentsAmmount++;
         WorldSpace.onWorldSpaceComponents[this.individualId] = this;
     }
 
+    /** Deletes itself and removes references if necessary. */
     Destroy() {
-        /*Deletes itself and removes references if necessary*/
-        //TODO
+        // TODO: Implement the destruction logic
         delete onWorldSpaceComponents[this.individualId];
-
-
     }
-    /*Vector2*/ handleGetPosition() {
+
+    /** Returns the position of the component. @returns {Vector2} - The position. */
+    handleGetPosition() {
         return this.position;
     }
 
-    handleSetPosition(/*Vector2*/ newPosition) {
+    /** Sets the position of the component. @param {Vector2} newPosition - The new position. */
+    handleSetPosition(newPosition) {
         this.position = newPosition;
     }
 
+    /** Gets the ID of the component. @returns {number} - The ID. */
     getId() {
         return this.individualId;
     }
 
+    /**
+     * Gets a WorldSpaceSubcomponentBehaviour instance by ID.
+     * @param {number} id - The ID of the component.
+     * @returns {WorldSpaceSubcomponentBehaviour} - The component instance.
+     */
     static getById(id) {
-
-        return WorldSpace.onWorldSpaceComponents[id]
-
+        return WorldSpace.onWorldSpaceComponents[id];
     }
 }

--- a/modules/workflow/src/js/utils/bus/graph-out-message.js
+++ b/modules/workflow/src/js/utils/bus/graph-out-message.js
@@ -1,0 +1,66 @@
+export class GraphOutMessage{
+
+
+    constructor(nodeGraph){
+        
+        this.nodeGraph = nodeGraph
+
+    }
+
+    outputToBus(graphRepresentation){
+
+    }
+
+    /*private*/getAttributesRepresentation(fields){
+        /*
+        Get the fields from the node and returns the output representation of it containing the fieldname and its value
+        E.G:
+
+        */
+        attributes = {}
+            for(let j = 0; j < fields.length;j++){
+                curField = fields[i]
+                attributes[curField.getName()] = curField.handleGetInputValue();
+            }
+        return attributes
+    }
+    getGraphRepresentation(){
+        /*
+        "nodes": [{
+            "id": int,
+            "type": string,
+            "attributes": {...}
+          }]
+
+        The id is not the same as the NodeId, it's easier to work with the new values E.G:
+          Workflow Nodes Ids:                   Output ids:
+          [33,22,43,543,657,123,123]            [0,1,2,3,4,5,6]
+        */
+        nodes = []
+
+
+        for(let i = 0 ; i < this.nodeGraph.length; i++){
+            currentNode = this.nodeGraph[i]
+            fields = currentNode.handleGetUserFields()
+            attributes = currentNode.handleGetUserFields(fields)
+            nodes.append(
+                {
+                    id:i, 
+                    type: currentNode.getNodeType(),
+                    attributes: attributes
+
+                }
+            )
+
+        }
+
+
+
+
+    }
+
+
+
+
+
+}

--- a/modules/workflow/src/js/utils/bus/graph-out-message.js
+++ b/modules/workflow/src/js/utils/bus/graph-out-message.js
@@ -1,5 +1,6 @@
-import { WorldSpaceNode } from "../../components/world-space-node";
-
+/**
+ * @typedef {Object.<string, any>} attributes
+ */
 export class GraphOutMessage{
 
 
@@ -19,7 +20,10 @@ export class GraphOutMessage{
         E.G:
 
         */
-        attributes = {}
+       
+
+
+        let attributes = {}
             for(let j = 0; j < fields.length;j++){
                 curField = fields[i]
                 attributes[curField.getName()] = curField.handleGetInputValue();
@@ -38,12 +42,35 @@ export class GraphOutMessage{
           Workflow Nodes Ids:                   Output ids:
           [33,22,43,543,657,123,123]            [0,1,2,3,4,5,6]
         */
-        let nodes = []
-        let edges = []
 
+        /**
+         * Stores attributes.
+         * @type {[
+         *      {     
+         * id:Number,
+         * type:String,   
+         * attributes : attributes
+         * }
+         * ]}
+         */
+
+        let nodes = []
+
+
+        /**
+         * Stores edges.
+         * @type {Array.<Array.<number,number>>}
+        */
+        let edges = []
+        
+        /**
+        * Stores edges.
+        * @type {Object.<Number, Number>}
+        */
         let newIds = {}
 
         for(let i = 0 ; i < this.nodeGraph.length; i++){
+            
             //Register the newIds and add the nodes
 
             let currentNode = this.nodeGraph[i]
@@ -78,13 +105,8 @@ export class GraphOutMessage{
 
         return {
             nodes:nodes,
-            edges,edges
+            edges:edges
         }
 
     }
-
-
-
-
-
 }

--- a/modules/workflow/src/js/utils/bus/graph-out-message.js
+++ b/modules/workflow/src/js/utils/bus/graph-out-message.js
@@ -1,3 +1,5 @@
+import { WorldSpaceNode } from "../../components/world-space-node";
+
 export class GraphOutMessage{
 
 
@@ -36,26 +38,48 @@ export class GraphOutMessage{
           Workflow Nodes Ids:                   Output ids:
           [33,22,43,543,657,123,123]            [0,1,2,3,4,5,6]
         */
-        nodes = []
+        let nodes = []
+        let edges = []
 
+        let newIds = {}
 
         for(let i = 0 ; i < this.nodeGraph.length; i++){
-            currentNode = this.nodeGraph[i]
-            fields = currentNode.handleGetUserFields()
-            attributes = currentNode.handleGetUserFields(fields)
+            //Register the newIds and add the nodes
+
+            let currentNode = this.nodeGraph[i]
+
+            currentId = currentNode.getId()
+            newIds[currentId] = i
+
+            const getNewId = (_old)=>{return newIds[_old]};
+
+            let fields = currentNode.handleGetUserFields()
+            let attributes = currentNode.handleGetUserFields(fields)
             nodes.append(
                 {
-                    id:i, 
+                    id:getNewId(currentId), 
                     type: currentNode.getNodeType(),
                     attributes: attributes
 
                 }
             )
+        }
+
+        for(let i = 0 ; i < this.nodeGraph.length; i++){
+            //Use the registered ids and add the edges
+            let targetNodes = currentNode.getTargetVertices()
+            targetNodes.forEach(target => {
+                edges.append([i,getNewId(target)])
+            });
+            
 
         }
 
 
-
+        return {
+            nodes:nodes,
+            edges,edges
+        }
 
     }
 

--- a/modules/workflow/src/js/world-space-node-types.js
+++ b/modules/workflow/src/js/world-space-node-types.js
@@ -10,12 +10,19 @@ export class WorldSpaceNodeTypes {
         } , ...
     }
     */
-  static NodeInfoLib = {};
+
+  
+    
+   static NodeInfoLib = {};
+
+    
+
+  
 
   static fetchNodes() {
     // fetch a JSON from the root of the project and parse it into the variable NodeInfoLib
     // this is a static method, so it can be called without creating an instance of the class
-
+    
     fetch("/availableCategories.json")
       .then((response) => {
         if (!response.ok) {


### PR DESCRIPTION
Added type hints to the following classes:
* WorldSpaceNodeConnector
* WorldSpaceNodeConnectorIn
* WorldSpaceNodeConnectorOut
* WorldSpaceSubcomponentBehaviour
* WorldSpaceNode

Why?
* It will help future features implementation, before, it was super complex to do so. 
* Reduce runtime erros due to type compatibility