### PR TITLE
Wf node list oid

### DIFF
--- a/modules/manifest.js
+++ b/modules/manifest.js
@@ -5,6 +5,9 @@ function getAvailableNodes(){
         {
             exampleCategory: [
                 ...nodeExample
+            ],
+            exampleCategory2: [
+                ...nodeExample
             ]
         }
     );

--- a/modules/presentation/components/application.js
+++ b/modules/presentation/components/application.js
@@ -1,5 +1,8 @@
 import { html, Oid, OidUI } from "/lib/oidlib-dev";
 import("/modules/workflow/src/js/components/workflow.js");
+import("/modules/workflow/src/js/components/component-provider-oid.js");
+import("/modules/workflow/src/js/interfaces.js");
+
 
 export class ApplicationOid extends OidUI {
   // presenting = false -> workflow
@@ -25,7 +28,7 @@ export class ApplicationOid extends OidUI {
         "flex";
     } else {
       this.shadowRoot.getElementById("workflow-container").style.display =
-        "block";
+        "flex";
       this.shadowRoot.getElementById("presentation-container").style.display =
         "none";
     }
@@ -61,25 +64,24 @@ export class ApplicationOid extends OidUI {
             <theme-switcher-oid><theme-switcher-oid />
           </div>
         </div>
-        <div id="presentation-container" class="flex-grow flex flex-col" style="display: none">
-          <presenter-oid
-            class="flex-grow flex flex-col"
-            subscribe="presentation/html~getJSONHTMLDescription;presentation/template~templateReady;presentation/tabs~tabChanged"
-          ></presenter-oid>
-          <builder-oid
-            subscribe="workflow/graph~getJSONHTML"
-            publish="returnJSONHTMLDescription~presentation/html"
-          ></builder-oid>
-          <mock-workflow-oid
-            publish="returnJSONHTML~workflow/graph"
-            subscribe="presentation/tabs~tabChanged"
-          ></mock-workflow-oid>
-        </div>
+          <div id="presentation-container" class="flex-grow flex flex-col" style="display: none">
+            <presenter-oid
+              class="flex-grow flex flex-col"
+              subscribe="presentation/html~getJSONHTMLDescription;presentation/template~templateReady;presentation/tabs~tabChanged"
+            ></presenter-oid>
+            <builder-oid
+              subscribe="workflow/graph~getJSONHTML"
+              publish="returnJSONHTMLDescription~presentation/html"
+            ></builder-oid>
+            <mock-workflow-oid
+              publish="returnJSONHTML~workflow/graph"
+              subscribe="presentation/tabs~tabChanged"
+            ></mock-workflow-oid>
+          </div>
+          <div id="workflow-container" class="w-full h-full flex items-stretch flex-grow">
+            <workflow-main-page class="w-full flex-grow"></workflow-main-page>
+          </div>
       </div>
-      <div id="workflow-container" class="w-full h-full">
-        <workflow-main-page class="w-full h-full"></workflow-main-page>
-      </div>
-      <div id="presentation-container" style="display: none">presentation</div>
     `;
   }
 
@@ -98,4 +100,5 @@ Oid.component({
   id: "presentation:application",
   element: "application-oid",
   implementation: ApplicationOid,
+  stylesheet: ['/style.css']
 });

--- a/modules/workflow/src/js/components/sidebar-node-list-view.js
+++ b/modules/workflow/src/js/components/sidebar-node-list-view.js
@@ -46,7 +46,7 @@ export class SidebarNodeListView extends OidUI {
         }
 
         return html`
-        <div class="w-full h-8">
+        <div class="w-full">
             <button
                 type="button"
                 @click="{{this._onClick}}"

--- a/modules/workflow/src/js/components/sidebar-node-list-view.js
+++ b/modules/workflow/src/js/components/sidebar-node-list-view.js
@@ -1,5 +1,4 @@
-import { parse } from "postcss";
-import { html, Oid, OidUI } from "../../../../../lib/oidlib-dev.js";
+import { html, Oid, OidUI } from "/lib/oidlib-dev.js";
 
 export class SidebarNodeListView extends OidUI {
     /** Represents the lists of nodes that will be in the sidebar
@@ -22,8 +21,10 @@ export class SidebarNodeListView extends OidUI {
      * @returns {Array.<Object>} - An array of objects with the type, name and icon fields
      */
     parseNodes() {
+        if (this.nodes == null) return [];
+
         const items = this.nodes.split(';');
-        const parsedItems = items.map(item => {
+        const parsedItems = items.filter(item => item != ' ').map(item => {
             const [type, name, icon] = item.trim().split(',');
             return {
                 type: type.trim(),
@@ -31,6 +32,7 @@ export class SidebarNodeListView extends OidUI {
                 icon: icon.trim(),
             };
         });
+
         return parsedItems;
     }
       
@@ -41,7 +43,6 @@ export class SidebarNodeListView extends OidUI {
 
         for (let node of parsedNodes) {
             template += `<li> <sidebar-node type="${node.type}" name="${node.name}" iconpath="${node.icon}" > </li>`;
-            console.log(node);
         }
 
         return html`
@@ -60,7 +61,7 @@ export class SidebarNodeListView extends OidUI {
                     viewBox="0 0 24 24"
                     stroke-width="1.5"
                     stroke="currentColor"
-                    class="w-6 h-6"
+                    class="w-6 h-6 stroke-primary"
                 >
                     <path
                         stroke-linecap="round"
@@ -85,7 +86,8 @@ export class SidebarNodeListView extends OidUI {
                 </svg>
             </button>
             <ul class="hidden mt-1 px-2 space-y-1">
-            ${template}</ul>
+                ${template}
+            </ul>
         </div>`;
     }
 }
@@ -95,8 +97,8 @@ Oid.component(
         id:'wf:sidebar-node-list',
         element:'sidebar-node-list',
         properties: {
-            name: {},
-            nodes: {}, //type1, name1, icon1 ; type2, name2, icon2 ...
+            name: {default: null},
+            nodes: {default: null}, //type1, name1, icon1 ; type2, name2, icon2 ...
         },
         implementation: SidebarNodeListView,
         stylesheet: ["/style.css"],

--- a/modules/workflow/src/js/components/sidebar.js
+++ b/modules/workflow/src/js/components/sidebar.js
@@ -1,24 +1,96 @@
-import { css, html, Oid, OidUI } from "../../../../../lib/oidlib-dev.js";
+import { html, Oid, OidUI } from "/lib/oidlib-dev.js";
 
 
-export class Sidebar extends OidUI {
+export class NodeListOid extends OidUI {
     /*
     Representa a barra que conterá os nodes para o usuário arrastá-los para o canvas.
     
     */
 
+    connectedCallback() {
+        super.connectedCallback();
+
+        // Gets all available nodes from library
+        const getNodeInfo = () => { return this._invoke("itf:component-provider", "getAllComponents", { }).then(success, fail) };
+        const success = (value) => {
+            
+            if (value != null) {
+                this.categories = value[0];
+                console.log(this.categories);
+            }
+            else {
+                setTimeout(getNodeInfo, 1200);
+            }
+        }
+        const fail = (reason) => { console.log(reason); }
+
+        getNodeInfo();
+    }
+
+    generateCategories() {
+        let partial = "", list;
+
+        if (this.categories == null)
+            return "";
+        
+        for (let category in this.categories) {
+            list = "";
+
+            for (let node of this.categories[category]) {
+                list += `${node.type}, ${node.name}, ${node.icon} ; `;
+            }
+
+            list.slice(0, list.length - 1);
+            partial += `
+            <sidebar-node-list name="${category}" nodes="${list}">
+            </sidebar-node-list>
+            `;
+        }
+
+        return partial;
+    }
+
+    template() {
+        const available = this.generateCategories();
+
+        return html`
+        <div class="w-64 h-full flex flex-col justify-between gap-4 bg-muted p-6 z-50 opacity-100 shadow-lg border-r">
+            <div class="flex flex-col gap-4">
+                <span class="text-xl font-semibold mb-4">Nodes</span>
+                ${available}
+            </div>
+            <div class="w-full flex items-center justify-center">
+                <!-- O botão abaixo deve disparar um evento para o módulo de apresentação -->
+                <!-- fazendo uma requisição da lista de templates. -->
+                <button-popover
+                label="Select Template"
+                publish="click~apresentacao/templates/requisicao; saved~workflow/saved"
+                class="grow">
+                </button-popover>
+                <!-- O componente de lista de templates recebe o evento da requisição, carrega o arquivo -->
+                <!-- que contém a lista de templates e dispara um evento com a lista de templates. -->
+                <template-lister-oid
+                class="hidden"
+                subscribe="apresentacao/templates/requisicao~requestTemplatesList"
+                publish="responseTemplatesList~apresentacao/templates/listagem"
+                >
+                </template-lister-oid>
+                <!-- O componente de seleção de templates recebe a lista de templates do barramento e -->
+                <!-- apresenta os templates disponível para o usuario escolher. -->
+            </div>
+        </div>
+        `;
+    }
 }
 
 Oid.component(
     {
-        id:'wf:sidebar',
-        element:'sidebar',
+        id:'wf:node-list-oid',
+        element:'node-list-oid',
         properties: {
+            categories: {default: null}
         },
-        implementation: Sidebar,
-        template: html`
-        <div>
-        </div>
-        `,
+        implementation: NodeListOid,
+        stylesheet: ['/style.css']
     }
 )

--- a/modules/workflow/src/js/components/workflow.js
+++ b/modules/workflow/src/js/components/workflow.js
@@ -1,6 +1,9 @@
 import { html, Oid, OidUI } from "/lib/oidlib-dev";
 import("/modules/workflow/src/js/components/template-selector.js");
 import("/modules/workflow/src/js/widgets/buttonPopover.js");
+import("/modules/workflow/src/js/components/sidebar.js");
+import("/modules/workflow/src/js/components/sidebar-node-list-view.js");
+import("/modules/workflow/src/js/components/sidebar-node-view.js");
 
 export class WorkflowOid extends OidUI {
   _onClick(event) {
@@ -44,120 +47,15 @@ export class WorkflowOid extends OidUI {
   
   template() {
     return html`
+      <component-provider-oid id="provider"></component-provider-oid>
       <div class="w-full h-full flex">
-        <div
-          class="w-80 h-full flex flex-col justify-between gap-4 bg-muted p-6 z-50 opacity-100 shadow-lg border-r"
-        >
-          <div class="flex flex-col gap-4">
-          <span class="text-xl font-semibold mb-4">Nodes</span>
-          <ul role="list" class="-mx-2 space-y-1">
-            <li>
-              <div>
-                <button
-                  type="button"
-                  @click
-                  class="hover:bg-background flex items-center w-full text-left rounded-md p-2 gap-x-3 text-sm leading-6 font-semibold text-primary"
-                  aria-controls="sub-menu-1"
-                  aria-expanded="false"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width="1.5"
-                    stroke="currentColor"
-                    class="w-6 h-6"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
-                    />
-                  </svg>
-                  Graphs
-                  <svg
-                    id="chevron"
-                    class="text-gray-400 ml-auto h-5 w-5 shrink-0"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </button>
-                <ul class="hidden mt-1 px-2 space-y-1" id="sub-menu-1">
-                  <li>
-                    <!-- 44px -->
-                    <a
-                      draggable="true"
-                      href="#"
-                      class="bg-background flex justify-between border rounded-md py-1.5 pl-2 pr-2 text-sm leading-6 text-primary"
-                      ><div class="flex gap-3">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke-width="1.5"
-                          stroke="currentColor"
-                          class="w-6 h-6"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z"
-                          />
-                        </svg>
-                        Scatter Graph
-                      </div>
-                      <div class="text-gray-400">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke-width="1.5"
-                          stroke="currentColor"
-                          class="w-6 h-6"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-                          />
-                        </svg>
-                      </div>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </li>
-          </ul>
+        <node-list-oid connect="itf:component-provider#provider"></node-list-oid>
+        <div class="w-full">
+          <div @mouseup={{this._onMouseUp}} @mousemove={{this._onMouseMove}} @mousedown={{this._onMouseDown}} class="w-full h-full overflow-hidden cursor-move relative">
+            <div id="node1" class="node w-32 h-32 bg-blue-500 absolute"></div>
+            <div id="node2" class="node w-32 h-32 bg-red-500 absolute"></div>
           </div>
-          <!-- O botão abaixo deve disparar um evento para o módulo de apresentação -->
-          <!-- fazendo uma requisição da lista de templates. -->
-          <button-popover
-            label="Select Template"
-            publish="click~apresentacao/templates/requisicao; saved~workflow/saved"
-          ></button-popover>
-          <!-- O componente de lista de templates recebe o evento da requisição, carrega o arquivo -->
-          <!-- que contém a lista de templates e dispara um evento com a lista de templates. -->
-          <template-lister-oid
-            class="hidden"
-            subscribe="apresentacao/templates/requisicao~requestTemplatesList"
-            publish="responseTemplatesList~apresentacao/templates/listagem"
-          >
-          </template-lister-oid>
-          <!-- O componente de seleção de templates recebe a lista de templates do barramento e -->
-          <!-- apresenta os templates disponível para o usuario escolher. -->
         </div>
-        <div class="w-full h-full ">
-        <div @mouseup={{this._onMouseUp}} @mousemove={{this._onMouseMove}} @mousedown={{this._onMouseDown}} class="w-full h-full overflow-hidden cursor-move relative">
-  <div id="node1" class="node w-32 h-32 bg-blue-500 absolute"></div>
-  <div id="node2" class="node w-32 h-32 bg-red-500 absolute"></div>
-</div></div>
       </div>
     `;
   }
@@ -168,4 +66,5 @@ Oid.component({
   id: "workflow:mainPage",
   element: "workflow-main-page",
   implementation: WorkflowOid,
+  stylesheet: ['/style.css']
 });

--- a/modules/workflow/src/js/components/world-space-node-view.js
+++ b/modules/workflow/src/js/components/world-space-node-view.js
@@ -1,5 +1,4 @@
 import { Bus, css, html, Oid, OidUI } from "/lib/oidlib-dev.js";
-import { WorldSpaceNodeTypes } from "../world-space-node-types.js";
 import { InputOid } from "../utils/input/input-field.js";
 import { NumberOid } from "../utils/input/number-field.js";
 import { RangeOid } from "../utils/input/range-input.js";

--- a/modules/workflow/src/js/components/world-space-node.js
+++ b/modules/workflow/src/js/components/world-space-node.js
@@ -1,7 +1,6 @@
 import { NodeInputField } from "./node-input-field.js";
 import { worldSpaceNodeConnectorIn, worldSpaceNodeConnectorOut } from "./connectors/index.js";
 import { WorldSpaceSubcomponentBehaviour } from "./world-space-subcomponent-behaviour.js"
-import { WorldSpaceNodeTypes } from "../world-space-node-types.js"
 import { WorldSpace } from "./world-space.js";
 
 export class WorldSpaceNode extends WorldSpaceSubcomponentBehaviour {


### PR DESCRIPTION
# Descrição

Cria o component `node-list-oid` responsável por renderizar dinamicamente os componentes disponíveis para construção do workflow.

## `node-list-oid`

O componente recebe do `component-provider-oid` os nós disponíveis a partir da interface  `itf:component-provider` e gera uma lista de *accordions* por categoria com os nós disponíveis como visto na imagem a seguir.

![localhost_5173_ (3)](https://github.com/mundorum-lab/datasci/assets/60759913/363e8d17-5238-4241-93e2-f582cfc40a0f)

Para adicionar categorias a lista de nós basta registrar so componentes no arquivo `manifest.js`
